### PR TITLE
Compatibility ggplot2 4.0.0

### DIFF
--- a/R/variable_plot.R
+++ b/R/variable_plot.R
@@ -189,7 +189,7 @@ variable_plot = function(data,
                                                               t = size * 0.2)),
                   strip.background = element_rect(fill = NA,
                                                   colour = NA,
-                                                  linewidth = NA),
+                                                  linewidth = 0),
                   strip.placement = "outside")
   }
 


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue is described in https://github.com/tidyverse/ggplot2/issues/6507, where you're welcome to raise discussion.

This PR repairs a misspecified linewidth. You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun